### PR TITLE
remove Dispatcher class?

### DIFF
--- a/spec/store_spec.ts
+++ b/spec/store_spec.ts
@@ -1,7 +1,7 @@
 declare var describe, it, expect, hot, cold, expectObservable, expectSubscriptions, console;
 require('es6-shim');
 import 'reflect-metadata';
-import {provideStore, Store, Dispatcher, Action} from '../src/store';
+import {provideStore, Store, Action} from '../src/store';
 import {Observable} from 'rxjs/Observable';
 import {Injector, provide} from 'angular2/core';
 
@@ -27,7 +27,6 @@ describe('ngRx Store', () => {
 
     let injector: Injector;
     let store: Store<TestAppSchema>;
-    let dispatcher: Dispatcher<Action>;
 
     beforeEach(() => {
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -36,12 +36,6 @@ export class Store<T> extends BehaviorSubject<T> {
 	}
 }
 
-export class Dispatcher<Action> extends Subject<Action> {
-	dispatch(action:Action){
-		this.next(action);
-	}
-}
-
 export const provideStore = (reducers:{[key:string]:Reducer<any>}, initialState:{[key:string]:any} = {}):any[] => {
 	
 	return [


### PR DESCRIPTION
Unless I'm mistaken, after this https://github.com/ngrx/store/commit/b50989aee7685d31f952dd03b74c8e55b3332cb9 there's no need to  have this https://github.com/ngrx/store/blob/master/src/store.ts#L39 class anymore, nor import it in spec..
