### PR TITLE
chore(package): target reflect-metadata 0.1.2 for angular beta.0 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jasmine": "^2.4.1",
     "jasmine-core": "^2.4.1",
     "lodash": "^3.10.1",
-    "reflect-metadata": "^0.1.2",
+    "reflect-metadata": "0.1.2",
     "typescript": "^1.7.3",
     "zone.js": "0.5.10"
   },


### PR DESCRIPTION
Fixes:

```
npm ERR! peerinvalid The package reflect-metadata@0.1.3 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer angular2@2.0.0-beta.0 wants reflect-metadata@0.1.2
```
