### PR TITLE
feat(store): Moved connection logic to a StoreBackend service

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@ngrx/store",
   "version": "1.2.1",
   "description": "RxJS powered Redux for Angular2 apps",
-  "main": "./dist/store.js",
+  "main": "./dist/index.js",
   "scripts": {
     "test": "npm run build_test && jasmine",
     "clean_ng2": "rimraf node_modules/angular2/manual_typings node_modules/angular2/typings",
@@ -10,7 +10,7 @@
     "build_test": "npm run clean_test && tsc -p spec",
     "build_dist": "rm -rf dist && tsc",
     "prepublish": "npm run typings && npm run build_dist",
-    "lint": "tslint src/store.ts",
+    "lint": "tslint src/**.ts",
     "typings": "typings install && npm run clean_ng2"
   },
   "repository": {
@@ -37,6 +37,7 @@
     "lodash": "^3.10.1",
     "reflect-metadata": "0.1.2",
     "rimraf": "^2.5.1",
+    "tslint": "^3.4.0",
     "typescript": "^1.7.3",
     "typings": "^0.6.6",
     "zone.js": "0.5.15"
@@ -45,5 +46,5 @@
     "rxjs": "^5.0.0-beta.2",
     "angular2": "2.0.0-beta.7"
   },
-  "typings": "./dist/store.d.ts"
+  "typings": "./dist/index.d.ts"
 }

--- a/spec/backend_spec.ts
+++ b/spec/backend_spec.ts
@@ -1,0 +1,80 @@
+declare var describe, it, expect, hot, cold, expectObservable, expectSubscriptions, console, beforeEach;
+require('es6-shim');
+import 'reflect-metadata';
+import {Observable} from 'rxjs/Observable';
+import {Subject} from 'rxjs/Subject';
+import {Injector, provide} from 'angular2/core';
+
+import {Dispatcher, StoreBackend, Action, usePreMiddleware, usePostMiddleware, provideStore} from '../src/index';
+import {ActionTypes} from '../src/store-backend';
+
+
+describe('ngRx Store Backend', () => {
+  const Reducer = { reduce: t => t };
+  const Middleware = { pre: t => t, post: t => t };
+  const initialState = 123;
+  let injector: Injector;
+  let backend: StoreBackend;
+  let dispatcher: Dispatcher<Action>;
+
+  beforeEach(() => {
+    spyOn(Reducer, 'reduce').and.callThrough();
+    spyOn(Middleware, 'pre').and.callThrough();
+    spyOn(Middleware, 'post').and.callThrough();
+
+    injector = Injector.resolveAndCreate([
+      provideStore<any>(Reducer.reduce, initialState),
+      usePreMiddleware(Middleware.pre),
+      usePostMiddleware(Middleware.post)
+    ]);
+
+    backend = injector.get(StoreBackend);
+    dispatcher = injector.get(Dispatcher);
+  });
+
+  it('should initialize the dispatcher after a connection is made', function() {
+
+    let action;
+
+    dispatcher.subscribe(a => {
+      action = a;
+    });
+
+    backend.connect(() => {});
+
+    expect(action).toEqual({ type: ActionTypes.INIT });
+
+  });
+
+  it('should call the reducer to scan over the dispatcher', function() {
+
+    const target = new Subject();
+    backend.connect(() => {});
+
+    expect(Reducer.reduce).toHaveBeenCalledWith(initialState, { type: ActionTypes.INIT });
+
+  });
+
+  it('should apply the middleware to the dispatcher', function() {
+
+    backend.connect(() => {});
+
+    expect(Middleware.pre).toHaveBeenCalledWith(dispatcher);
+    expect(Middleware.post).toHaveBeenCalled();
+
+  });
+
+  it('should replace the reducer for existing existing connections', function() {
+
+    const NewReducer = { reduce: () => 234 };
+    spyOn(NewReducer, 'reduce').and.callThrough();
+    let lastValue: any;
+    backend.connect(t => lastValue = t);
+    backend.replaceReducer(NewReducer.reduce);
+
+    expect(NewReducer.reduce).toHaveBeenCalledWith(initialState, { type: ActionTypes.INIT });
+    expect(lastValue).toEqual(234);
+
+  });
+
+});

--- a/spec/integration_spec.ts
+++ b/spec/integration_spec.ts
@@ -1,7 +1,8 @@
 declare var describe, it, expect, hot, cold, expectObservable, expectSubscriptions, console;
 require('es6-shim');
 import 'reflect-metadata';
-import {Store, Action, combineReducers, provideStore} from '../src/index';
+import {Store, Action, combineReducers} from '../src/index';
+import {provideStore} from '../src/ng2';
 import {Observable} from 'rxjs/Observable';
 import {Injector, provide} from 'angular2/core';
 import 'rxjs/add/observable/combineLatest';
@@ -28,12 +29,15 @@ describe('ngRx Integration spec', () => {
     let store: Store<TodoAppSchema>;
     let currentState: TodoAppSchema;
 
+    const rootReducer = combineReducers({ todos, visibilityFilter });
+    const initialValue = { todos: [], visibilityFilter: VisibilityFilters.SHOW_ALL };
+
     injector = Injector.resolveAndCreate([
-      provideStore({ todos, visibilityFilter }, { todos: [], visibilityFilter: VisibilityFilters.SHOW_ALL })
+      provideStore(rootReducer, initialValue)
     ]);
 
     store = injector.get(Store);
-    
+
     store.subscribe(state => {
       currentState = state;
     });

--- a/spec/store_spec.ts
+++ b/spec/store_spec.ts
@@ -1,7 +1,8 @@
 declare var describe, it, expect, hot, cold, expectObservable, expectSubscriptions, console, beforeEach;
 require('es6-shim');
 import 'reflect-metadata';
-import {Store, Dispatcher, Action, provideStore} from '../src/index';
+import {Store, Dispatcher, StoreBackend, Action, combineReducers} from '../src/index';
+import {provideStore} from '../src/ng2';
 import {Observable} from 'rxjs/Observable';
 import {Injector, provide} from 'angular2/core';
 
@@ -28,17 +29,23 @@ describe('ngRx Store', () => {
 
     let injector: Injector;
     let store: Store<TestAppSchema>;
-    let dispatcher:Dispatcher;
+    let dispatcher: Dispatcher<Action>;
 
     beforeEach(() => {
+      const rootReducer = combineReducers({
+        counter1: counterReducer,
+        counter2: counterReducer,
+        counter3: counterReducer
+      });
+
+      const initialValue = { counter1: 0, counter2: 1 };
 
       injector = Injector.resolveAndCreate([
-        provideStore({ counter1: counterReducer, counter2: counterReducer, counter3: counterReducer }, { counter1: 0, counter2: 1 })
+        provideStore(rootReducer, initialValue)
       ]);
 
       store = injector.get(Store);
       dispatcher = injector.get(Dispatcher);
-
     });
 
     it('should provide an Observable Store', () => {
@@ -180,13 +187,26 @@ describe('ngRx Store', () => {
       store.dispatch({type: INCREMENT});
       expect(currentState).toEqual({counter1: 1, counter2: 2, counter3: 1});
 
-      store.replaceReducers({'dynamicCounter' : counterReducer});
+      store.replaceReducer(combineReducers({ counter1: counterReducer, dynamicCounter: counterReducer}));
 
-      expect(currentState).toEqual({counter1: 1, counter2: 2, counter3: 1, dynamicCounter: 0});
+      expect(currentState).toEqual({ counter1: 1, dynamicCounter: 0 });
 
       store.dispatch({type: INCREMENT});
 
-      expect(currentState).toEqual({counter1: 2, counter2: 3, counter3: 2, dynamicCounter: 1});
+      expect(currentState).toEqual({ counter1: 2, dynamicCounter: 1 });
+
+    });
+
+    it('should implement the observer interface forwarding actions and errors to the dispatcher', function() {
+
+      spyOn(dispatcher, 'next');
+      spyOn(dispatcher, 'error');
+
+      store.next(1);
+      store.error(2);
+
+      expect(dispatcher.next).toHaveBeenCalledWith(1);
+      expect(dispatcher.error).toHaveBeenCalledWith(2);
 
     });
   });

--- a/spec/tsconfig.json
+++ b/spec/tsconfig.json
@@ -11,6 +11,7 @@
     "../typings/main.d.ts",
 		"helpers/test-helper.ts",
     "integration_spec.ts",
-		"store_spec.ts"
+		"store_spec.ts",
+		"backend_spec.ts"
 	]
 }

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -1,0 +1,10 @@
+import {Subject} from 'rxjs/Subject';
+import {Observable} from 'rxjs/Observable';
+
+import {Action} from './interfaces';
+
+export class Dispatcher<T> extends Subject<T> {
+  dispatch(action: T): void {
+    this.next(action);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,6 @@
-import {provide} from 'angular2/core';
-
-import {Store, Dispatcher, provideStoreFn} from './store';
-
-export const provideStore = provideStoreFn(provide);
-
-export {Store, Dispatcher}
-
 export * from './interfaces';
-
+export * from './store';
 export * from './utils';
+export * from './dispatcher';
+export * from './store-backend';
+export * from './ng2';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,3 +1,4 @@
+import {Observable} from 'rxjs/Observable';
 import {Store} from './store';
 
 export interface Action {
@@ -9,10 +10,6 @@ export interface Reducer<T> {
   (state: T, action: Action): T;
 }
 
-export interface StoreCreator {
-  (reducer: Reducer<any>, initialState: {[key:string]: any}): Store<any>
-}
-
-export interface StoreEnhancer {
-  (next: StoreCreator): StoreCreator;
+export interface Middleware {
+  (observable: Observable<any>): Observable<any>;
 }

--- a/src/ng2.ts
+++ b/src/ng2.ts
@@ -1,0 +1,83 @@
+import {provide, OpaqueToken, Provider} from 'angular2/core';
+
+import {Reducer, Middleware} from './interfaces';
+import {Dispatcher} from './dispatcher';
+import {Store} from './store';
+import {StoreBackend} from './store-backend';
+import {compose} from './utils';
+
+export const PRE_MIDDLEWARE = new OpaqueToken('ngrx/store/pre-middleware');
+export const POST_MIDDLEWARE = new OpaqueToken('ngrx/store/post-middleware')
+export const RESOLVED_PRE_MIDDLEWARE = new OpaqueToken('ngrx/store/resolved-pre-middleware');
+export const RESOLVED_POST_MIDDLEWARE = new OpaqueToken('ngrx/store/resolved-post-middleware');
+export const REDUCER = new OpaqueToken('ngrx/store/reducer');
+export const INITIAL_STATE = new OpaqueToken('ngrx/store/initial-state');
+
+const dispatcherProvider = provide(Dispatcher, {
+  useFactory() {
+    return new Dispatcher<any>();
+  }
+});
+
+const storeProvider = provide(Store, {
+  deps: [Dispatcher, StoreBackend, INITIAL_STATE],
+  useFactory(dispatcher: Dispatcher<any>, backend: StoreBackend, initialState: any) {
+      return new Store<any>(dispatcher, backend, initialState);
+  }
+});
+
+const storeBackendProvider = provide(StoreBackend, {
+  deps: [Dispatcher, REDUCER, INITIAL_STATE, RESOLVED_PRE_MIDDLEWARE, RESOLVED_POST_MIDDLEWARE],
+  useFactory(
+    dispatcher: Dispatcher<any>,
+    reducer: Reducer<any>,
+    initialState: any,
+    preMiddleware: Middleware,
+    postMiddleware: Middleware
+  ) {
+    return new StoreBackend(dispatcher, reducer, initialState, preMiddleware, postMiddleware);
+  }
+});
+
+const resolvedPreMiddlewareProvider = provide(RESOLVED_PRE_MIDDLEWARE, {
+  deps: [PRE_MIDDLEWARE],
+  useFactory(middleware: Middleware[]) {
+    return compose(...middleware);
+  }
+});
+
+const resolvedPostMiddlewareProvider = provide(RESOLVED_POST_MIDDLEWARE, {
+  deps: [POST_MIDDLEWARE],
+  useFactory(middleware: Middleware[]) {
+    return compose(...middleware);
+  }
+});
+
+export function provideStore<T>(reducer: Reducer<T>, initialState?: T) {
+  return [
+    provide(REDUCER, { useValue: reducer }),
+    provide(INITIAL_STATE, { useValue: initialState }),
+    provide(PRE_MIDDLEWARE, { multi: true, useValue: (T => T) }),
+    provide(POST_MIDDLEWARE, { multi: true, useValue: (T => T) }),
+    dispatcherProvider,
+    storeProvider,
+    storeBackendProvider,
+    resolvedPreMiddlewareProvider,
+    resolvedPostMiddlewareProvider
+  ];
+}
+
+export function usePreMiddleware(...middleware: Middleware[]) {
+  return provideMiddlewareForToken(PRE_MIDDLEWARE, middleware);
+}
+
+export function usePostMiddleware(...middleware: Middleware[]) {
+  return provideMiddlewareForToken(POST_MIDDLEWARE, middleware);
+}
+
+function provideMiddlewareForToken(token, middleware: any[]){
+  return middleware.map(m => provide(token, {
+    multi: true,
+    useValue: m
+  }));
+}

--- a/src/store-backend.ts
+++ b/src/store-backend.ts
@@ -1,0 +1,40 @@
+import {Subject} from 'rxjs/Subject';
+import 'rxjs/add/operator/let';
+import 'rxjs/add/operator/scan';
+
+import {Dispatcher} from './dispatcher';
+import {Middleware, Reducer} from './interfaces';
+
+export const ActionTypes = {
+  INIT: '@@ngrx/INIT'
+};
+
+export class StoreBackend {
+  constructor(
+    protected _dispatcher: Dispatcher<any>,
+    protected _reducer: Reducer<any>,
+    protected _initialState: any,
+    protected _preMiddleware: Middleware = t => t,
+    protected _postMiddleware: Middleware = t => t
+  ) { }
+
+  protected _init() {
+    this._dispatcher.dispatch({ type: ActionTypes.INIT });
+  }
+
+  connect(nextCallbackFn: (state: any) => void) {
+    this._dispatcher
+      .let(this._preMiddleware)
+      .scan((state, action) => this._reducer(state, action), this._initialState)
+      .let(this._postMiddleware)
+      .subscribe(nextCallbackFn);
+
+    this._init();
+  }
+
+  replaceReducer(reducer: Reducer<any>) {
+    this._reducer = reducer;
+
+    this._init();
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,35 +1,43 @@
 import {Reducer} from './interfaces';
 
-export const combineReducers = (reducers:any): Reducer<any> => {
-
+export function combineReducers(reducers: any): Reducer<any> {
   const reducerKeys = Object.keys(reducers);
+  const finalReducers = {};
 
-  return (state = {}, action) => {
+  for (let i = 0; i < reducerKeys.length; i++) {
+    const key = reducerKeys[i];
+    if (typeof reducers[key] === 'function') {
+      finalReducers[key] = reducers[key];
+    }
+  }
 
+  const finalReducerKeys = Object.keys(finalReducers);
+
+  return function combination(state = {}, action) {
     let hasChanged = false;
     const nextState = {};
-    for (var i = 0; i < reducerKeys.length; i++) {
-      const key = reducerKeys[i];
-      const reducer = reducers[key];
-      const previousState = state[key];
-      const newState = reducer(previousState, action);
-      nextState[key] = newState;
-      hasChanged = hasChanged || previousState !== newState;
+    for (let i = 0; i < finalReducerKeys.length; i++) {
+      const key = finalReducerKeys[i];
+      const reducer = finalReducers[key];
+      const previousStateForKey = state[key];
+      const nextStateForKey = reducer(previousStateForKey, action);
+
+      nextState[key] = nextStateForKey;
+      hasChanged = hasChanged || nextStateForKey !== previousStateForKey;
     }
     return hasChanged ? nextState : state;
-  }
+  };
 }
-
 
 export const compose = (...funcs) => {
   return (...args) => {
     if (funcs.length === 0) {
-      return args[0]
+      return args[0];
     }
 
-    const last = funcs[funcs.length - 1]
-    const rest = funcs.slice(0, -1)
+    const last = funcs[funcs.length - 1];
+    const rest = funcs.slice(0, -1);
 
-    return rest.reduceRight((composed, f) => f(composed), last(...args))
-  }
-}
+    return rest.reduceRight((composed, f) => f(composed), last(...args));
+  };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,10 @@
 	"files": [
     "typings/main.d.ts",
     "src/index.ts",
-		"src/store.ts"
+		"src/store.ts",
+		"src/store-backend.ts",
+		"src/dispatcher.ts",
+		"src/ng2.ts"
 	],
 	"exclude": [
 		"node_modules"


### PR DESCRIPTION
This is a pretty heavy refactor. Changes:
1. Introduce a `StoreBackend` service. This change makes it easy for future devtools to lift both the state and action stream without having to modify the `Store` class. This service has three responsibilities:
   1. Apply middleware to the action dispatcher
   2. Connect the action dispatcher to any subject
   3. Replace the action reducer during runtime
2. Re-introduce the `Dispatcher` service. This makes it easy to apply middleware to the action stream and for devtools to wrap it.
3. Create a pipeline for applying a middleware function to the `Action` stream. This uses the `let` operator on the `Action` observable.
4. Simplify `reducer` throughout entire library. Now reducers are just a function. Simplifies `replaceReducer` as well.
5. Move all Angular 2 specific code to `ng2.ts`. This just wires up the services using Angular 2's DI. `provideStore(reducerFn, initialState)` sets up the services, and `useMiddleware(...middleware: Middleware[])` adds middleware to the middleware pipeline. This should make it a little easier for others to use ngrx/store with a different framework.  

I've modified all of the tests to verify they work against the new architecture. Realizing now that I'm missing tests for middleware, those are forthcoming. 
