### PR TITLE
feat(Reducer): Automatically combine reducers if a key/value map is provided

### DIFF
--- a/spec/backend_spec.ts
+++ b/spec/backend_spec.ts
@@ -23,7 +23,7 @@ describe('ngRx Store Backend', () => {
     spyOn(Middleware, 'post').and.callThrough();
 
     injector = Injector.resolveAndCreate([
-      provideStore<any>(Reducer.reduce, initialState),
+      provideStore(Reducer.reduce, initialState),
       usePreMiddleware(Middleware.pre),
       usePostMiddleware(Middleware.post)
     ]);

--- a/spec/integration_spec.ts
+++ b/spec/integration_spec.ts
@@ -1,7 +1,7 @@
 declare var describe, it, expect, hot, cold, expectObservable, expectSubscriptions, console;
 require('es6-shim');
 import 'reflect-metadata';
-import {Store, Action, combineReducers} from '../src/index';
+import {Store, Action, combineReducers, REDUCER} from '../src/index';
 import {provideStore} from '../src/ng2';
 import {Observable} from 'rxjs/Observable';
 import {Injector, provide} from 'angular2/core';
@@ -44,6 +44,20 @@ describe('ngRx Integration spec', () => {
 
     it('should successfully instantiate', () => {
       expect(store).toBeDefined();
+    });
+
+    it('should combine reducers automatically if a key/value map is provided', () => {
+      const reducers = { test: function(){} };
+      spyOn(reducers, 'test');
+      const action = { type: 'Test Action' };
+      const reducer = Injector.resolveAndCreate([ provideStore(reducers) ]).get(REDUCER);
+
+      expect(reducer).toBeDefined();
+      expect(typeof reducer === 'function').toBe(true);
+
+      reducer(undefined, action);
+
+      expect(reducers.test).toHaveBeenCalledWith(undefined, action);
     });
 
     it('should start with no todos and showing all filter', () => {

--- a/src/ng2.ts
+++ b/src/ng2.ts
@@ -4,7 +4,7 @@ import {Reducer, Middleware} from './interfaces';
 import {Dispatcher} from './dispatcher';
 import {Store} from './store';
 import {StoreBackend} from './store-backend';
-import {compose} from './utils';
+import {compose, combineReducers} from './utils';
 
 export const PRE_MIDDLEWARE = new OpaqueToken('ngrx/store/pre-middleware');
 export const POST_MIDDLEWARE = new OpaqueToken('ngrx/store/post-middleware')
@@ -53,7 +53,8 @@ const resolvedPostMiddlewareProvider = provide(RESOLVED_POST_MIDDLEWARE, {
   }
 });
 
-export function provideStore<T>(reducer: Reducer<T>, initialState?: T) {
+export function provideStore(_reducer: any, initialState?: any) {
+  const reducer = typeof _reducer === 'function' ? _reducer : combineReducers(_reducer);
   return [
     provide(REDUCER, { useValue: reducer }),
     provide(INITIAL_STATE, { useValue: initialState }),


### PR DESCRIPTION
In `provideStore`, if the reducer is not a function it will apply `combineReducers` to it under the expectation that it is a key/value map of reducers. 

Also changed the signature of `provideStore` from:

``` ts
provideStore<T>(reducer: Reducer<T>, initialState?: T);
```

to:

``` ts
provideStore(reducer: any, initialState?: any);
```
