### PR TITLE
feat(middleware): Use providers as middleware

### DIFF
--- a/spec/ng2_spec.ts
+++ b/spec/ng2_spec.ts
@@ -1,0 +1,38 @@
+declare var describe, it, expect, hot, cold, expectObservable, expectSubscriptions, console, beforeEach;
+require('es6-shim');
+import 'reflect-metadata';
+import {Observable} from 'rxjs/Observable';
+import {Subject} from 'rxjs/Subject';
+import {Injector, provide, OpaqueToken} from 'angular2/core';
+
+import {StoreBackend, usePreMiddleware, usePostMiddleware, RESOLVED_PRE_MIDDLEWARE, provideStore} from '../src';
+
+
+describe('ngRx Angular 2 Bindings', () => {
+
+  describe('Middleware', () => {
+    it('should allow you to compose middleware using providers', () => {
+      const first = { apply: t => t };
+      const second = { apply: t => t };
+      const third = { apply: t => t };
+
+      spyOn(first, 'apply');
+      spyOn(second, 'apply');
+      spyOn(third, 'apply');
+
+      const secondProvider = provide(new OpaqueToken('Second Midleware'), { useValue: second.apply });
+      const injector = Injector.resolveAndCreate([
+        provideStore((_, a) => a),
+        usePreMiddleware(first.apply, secondProvider, third.apply)
+      ]);
+
+      const preMiddleware = injector.get(RESOLVED_PRE_MIDDLEWARE);
+      preMiddleware();
+
+      expect(first.apply).toHaveBeenCalled();
+      expect(second.apply).toHaveBeenCalled();
+      expect(third.apply).toHaveBeenCalled();
+    });
+  });
+
+});

--- a/spec/ng2_spec.ts
+++ b/spec/ng2_spec.ts
@@ -5,7 +5,14 @@ import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 import {Injector, provide, OpaqueToken} from 'angular2/core';
 
-import {StoreBackend, usePreMiddleware, usePostMiddleware, RESOLVED_PRE_MIDDLEWARE, provideStore} from '../src';
+import {
+  StoreBackend,
+  usePreMiddleware,
+  usePostMiddleware,
+  RESOLVED_PRE_MIDDLEWARE,
+  provideStore,
+  createMiddleware
+} from '../src';
 
 
 describe('ngRx Angular 2 Bindings', () => {
@@ -21,9 +28,10 @@ describe('ngRx Angular 2 Bindings', () => {
       spyOn(third, 'apply');
 
       const secondProvider = provide(new OpaqueToken('Second Midleware'), { useValue: second.apply });
+      const thirdProvider = createMiddleware(() => third.apply);
       const injector = Injector.resolveAndCreate([
         provideStore((_, a) => a),
-        usePreMiddleware(first.apply, secondProvider, third.apply)
+        usePreMiddleware(first.apply, secondProvider, thirdProvider)
       ]);
 
       const preMiddleware = injector.get(RESOLVED_PRE_MIDDLEWARE);

--- a/spec/tsconfig.json
+++ b/spec/tsconfig.json
@@ -12,6 +12,7 @@
 		"helpers/test-helper.ts",
     "integration_spec.ts",
 		"store_spec.ts",
-		"backend_spec.ts"
+		"backend_spec.ts",
+		"ng2_spec.ts"
 	]
 }

--- a/src/ng2.ts
+++ b/src/ng2.ts
@@ -1,4 +1,4 @@
-import {provide, OpaqueToken, Provider} from 'angular2/core';
+import {provide, OpaqueToken, Provider, Injector} from 'angular2/core';
 
 import {Reducer, Middleware} from './interfaces';
 import {Dispatcher} from './dispatcher';
@@ -84,17 +84,34 @@ export function provideStore(reducer: any, initialState?: any) {
   ];
 }
 
-export function usePreMiddleware(...middleware: Middleware[]) {
+export function usePreMiddleware(...middleware: Array<Middleware | Provider>) {
   return provideMiddlewareForToken(PRE_MIDDLEWARE, middleware);
 }
 
-export function usePostMiddleware(...middleware: Middleware[]) {
+export function usePostMiddleware(...middleware: Array<Middleware | Provider>) {
   return provideMiddlewareForToken(POST_MIDDLEWARE, middleware);
 }
 
-function provideMiddlewareForToken(token, middleware: any[]){
-  return middleware.map(m => provide(token, {
+function provideMiddlewareForToken(token, _middleware: any[]): Provider[]{
+  function isProvider(t: any): t is Provider{
+    return t instanceof Provider;
+  }
+
+  const provider = provide(token, {
     multi: true,
-    useValue: m
-  }));
+    deps: [ Injector ],
+    useFactory(injector: Injector){
+      const middleware = _middleware.map(m => {
+        if(isProvider(m)){
+          return injector.get(m.token);
+        }
+
+        return m;
+      });
+
+      return compose(...middleware);
+    }
+  });
+
+  return [ ..._middleware.filter(isProvider), provider ];
 }

--- a/src/ng2.ts
+++ b/src/ng2.ts
@@ -92,7 +92,16 @@ export function usePostMiddleware(...middleware: Array<Middleware | Provider>) {
   return provideMiddlewareForToken(POST_MIDDLEWARE, middleware);
 }
 
-function provideMiddlewareForToken(token, _middleware: any[]): Provider[]{
+export function createMiddleware(
+  useFactory: (...deps: any[]) => Middleware, deps?: any[]
+): Provider {
+  return provide(new OpaqueToken('@ngrx/store middleware'), {
+    deps,
+    useFactory
+  });
+}
+
+export function provideMiddlewareForToken(token, _middleware: any[]): Provider[] {
   function isProvider(t: any): t is Provider{
     return t instanceof Provider;
   }


### PR DESCRIPTION
This PR tries to solve some ergonomic issues surrounding middleware factories created via DI.

A lot of middleware will need to use the injector to resolve dependencies, like my [store-saga example](https://github.com/MikeRyan52/store-saga/blob/master/lib/index.ts#L22). While using a `multi` provider for the `PRE_MIDDLEWARE` or `POST_MIDDLEWARE` token works it restricts the consumer from being able to specify the order they want middleware to be applied.

This PR changes `usePreMiddleware` and `usePostMiddleware` to accept either middleware functions or instances of the `Provider` class. As part of resolution it will use the injector to resolve the middleware providers and compose all of the middleware in the order they are specified. To further improve their utility, these middleware functions reflect back any providers passed into them.

Demo:

``` js
const log: Middleware = input$ => input$.do(item => console.log(item));

const thunk = provide(new OpaqueToken('Thunk Middleware'), {
  deps: [Dispatcher],
  useFactory(dispatcher: Dispatcher<Action>): Middleware{
    return function(all$: Observable<Action | Thunk>){
      const [thunks$, actions$] = all$.partition(t => typeof t === 'function');

      thunks$
        .map(thunk => return new Observable(observer => {
          thunk(action => observer.next(action));
        }))
        .mergeAll()
        .subscribe(dispatcher);

      return actions$;
    }
  }
});

bootstrap(App, [ provideStore(reducer), usePreMiddleware(thunk, log) ]);
```
