### PR TITLE
Added note about createMiddleware helper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Store middleware provides pre and post reducer entry points for all dispatched a
 
 Middleware can be configured during application bootstrap by utilizing the `usePreMiddleware(...middleware: Middleware[])` and `usePostMiddleware(...middleware: Middleware[])` helper functions. 
 
+####usage
+*Warning: Remember to import all utilized RxJS operators.*
+
 ```typescript
 import {bootstrap} from 'angular2/platform/browser';
 import {App} from './myapp';
@@ -127,11 +130,27 @@ bootstrap(App, [
 ```
 For a more complex example check out [store-saga](https://github.com/MikeRyan52/store-saga), an ngrx store middleware implementation inspired by [redux saga](https://github.com/yelouafi/redux-saga).
 
+####Middleware with Dependencies
+For middleware requiring dependencies the `createMiddleware(useFactory: (...deps: any[]) => Middleware, deps?: any[]): Provider` helper function is supplied. This allows you to quickly create middleware that relies on other Angular services, such as the `Dispatcher`.
+####usage
+```typescript
+const thunk = createMiddleware(function(dispatcher: Dispatcher<Action>): Middleware{
+  return function(all$: Observable<Action | Thunk>){
+    const [thunks$, actions$] = all$.partition(t => typeof t === 'function');
+
+    thunks$
+      .map(thunk => return new Observable(observer => {
+        thunk(action => observer.next(action));
+      }))
+      .mergeAll()
+      .subscribe(dispatcher);
+
+    return actions$;
+  }
+}, [ Dispatcher ]);
+```
+
 ## Contributing
 
 Please read [contributing guidelines here](https://github.com/ngrx/store/blob/master/CONTRIBUTING.md).
-
-
-
-
 

--- a/README.md
+++ b/README.md
@@ -128,28 +128,35 @@ bootstrap(App, [
   usePostMiddleware(stateLog)
 ]);
 ```
-For a more complex example check out [store-saga](https://github.com/MikeRyan52/store-saga), an ngrx store middleware implementation inspired by [redux saga](https://github.com/yelouafi/redux-saga).
 
 ####Middleware with Dependencies
 For middleware requiring dependencies the `createMiddleware(useFactory: (...deps: any[]) => Middleware, deps?: any[]): Provider` helper function is supplied. This allows you to quickly create middleware that relies on other Angular services, such as the `Dispatcher`.
 ####usage
+- Create middleware provider:
 ```typescript
-const thunk = createMiddleware(function(dispatcher: Dispatcher<Action>): Middleware{
+export const thunk = createMiddleware(function(dispatcher: Dispatcher<Action>) {
   return function(all$: Observable<Action | Thunk>){
     const [thunks$, actions$] = all$.partition(t => typeof t === 'function');
 
-    thunks$
-      .map(thunk => return new Observable(observer => {
-        thunk(action => observer.next(action));
-      }))
-      .mergeAll()
-      .subscribe(dispatcher);
+    thunks$.forEach(thunk => thunk(action => dispatcher.dispatch(action));
 
     return actions$;
   }
-}, [ Dispatcher ]);
+}, [Dispatcher]);
 ```
+- Initialize with `usePreMiddleware(...middleware: Middleware[])` or `usePostMiddleware(...middleware: Middleware[])` on application bootstrap:
+```typescript
+import {bootstrap} from 'angular2/platform/browser';
+import {App} from './myapp';
+import {provideStore, usePreMiddleware, Middleware} from '@ngrx/store';
+import {thunk} from './thunk';
+import {exampleReducer} from './exampleReducer';
 
+bootstrap(App, [
+  provideStore({exampleReducer}),
+  usePreMiddleware(thunk)
+]);
+```
 ## Contributing
 
 Please read [contributing guidelines here](https://github.com/ngrx/store/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
I added a note and example for the new createMiddleware helper function. I also added a warning before the basic middleware example reminding developers to import the correct RxJS operators. There have been 2 issues opened and multiple questions in chat regarding this problem within the past week.

Long term I am going to start working on more comprehensive documentation for the github.io site. This will help new users hit the ground running as this project continues to grow in popularity!
