### PR TITLE
fix(store): use trampoline scheduler

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,10 @@
     "reflect-metadata": "0.1.2",
     "rimraf": "^2.5.1",
     "tslint": "^3.4.0",
-    "typescript": "^1.7.3",
+    "typescript": "1.8.9",
     "typings": "^0.6.6",
-    "zone.js": "0.5.15"
+    "zone.js": "0.5.15",
+    "rxjs": "5.0.0-beta.2"
   },
   "peerDependencies": {
     "rxjs": "^5.0.0-beta.2",

--- a/spec/edge_spec.ts
+++ b/spec/edge_spec.ts
@@ -1,0 +1,74 @@
+declare var describe, fit, it, expect, hot, cold, expectObservable, expectSubscriptions, console, beforeEach;
+require('es6-shim');
+import 'reflect-metadata';
+import {Store, Dispatcher, StoreBackend, Action, combineReducers} from '../src/index';
+import {provideStore} from '../src/ng2';
+import {Observable} from 'rxjs/Observable';
+import {Injector, provide} from 'angular2/core';
+
+import {todos, todoCount} from './fixtures/edge_todos';
+
+interface TestAppSchema {
+  counter1: number;
+  counter2: number;
+  counter3: number;
+}
+
+interface Todo { }
+
+interface TodoAppSchema {
+  visibilityFilter: string;
+  todos: Todo[];
+}
+
+
+
+describe('ngRx Store', () => {
+
+  describe('basic store actions', function() {
+
+    let injector: Injector;
+    let store: Store<TestAppSchema>;
+    let dispatcher: Dispatcher<Action>;
+
+    beforeEach(() => {
+
+      injector = Injector.resolveAndCreate([
+        provideStore({ todos, todoCount })
+      ]);
+
+      store = injector.get(Store);
+      dispatcher = injector.get(Dispatcher);
+    });
+
+    it('should provide an Observable Store', () => {
+      expect(store).toBeDefined();
+    });
+
+    it('should handle re-entrancy', (done) => {
+
+      let todosNextCount = 0;
+      let todosCountNextCount = 0;
+
+      store.select('todos').subscribe((todos: any[]) => {
+        todosNextCount++
+        store.dispatch({ type: 'SET_COUNT', payload: todos.length })
+      });
+
+      store.select('todoCount').subscribe(count => {
+        todosCountNextCount++;
+      });
+
+      store.dispatch({ type: 'ADD_TODO', payload: { name: 'test' } });
+      expect(todosNextCount).toBe(2);
+      expect(todosCountNextCount).toBe(2);
+
+      setTimeout(() => {
+        expect(todosNextCount).toBe(2);
+        expect(todosCountNextCount).toBe(2);
+        done();
+      }, 10);
+
+    });
+  });
+});

--- a/spec/fixtures/edge_todos.ts
+++ b/spec/fixtures/edge_todos.ts
@@ -1,0 +1,46 @@
+const todo = (state, action) => {
+  switch (action.type) {
+    case 'ADD_TODO':
+      return {
+        id: action.payload.id,
+        text: action.payload.text,
+        completed: false
+      }
+    case 'TOGGLE_TODO':
+      if (state.id !== action.id) {
+        return state
+      }
+
+      return Object.assign({}, state, {
+        completed: !state.completed
+      })
+
+    default:
+      return state
+  }
+}
+
+export const todos = (state = [], action) => {
+  switch (action.type) {
+    case 'ADD_TODO':
+      return [
+        ...state,
+        todo(undefined, action)
+      ]
+    case 'TOGGLE_TODO':
+      return state.map(t =>
+        todo(t, action)
+      )
+    default:
+      return state
+  }
+}
+
+export const todoCount = (state = 0, action) => {
+  switch(action.type){
+    case 'SET_COUNT':
+      return action.payload;
+    default:
+      return state;
+  }
+}

--- a/spec/tsconfig.json
+++ b/spec/tsconfig.json
@@ -13,6 +13,7 @@
     "integration_spec.ts",
 		"store_spec.ts",
 		"backend_spec.ts",
-		"ng2_spec.ts"
+		"ng2_spec.ts",
+    "edge_spec.ts"
 	]
 }

--- a/src/store-backend.ts
+++ b/src/store-backend.ts
@@ -1,6 +1,8 @@
 import {Subject} from 'rxjs/Subject';
+import {queue} from 'rxjs/scheduler/queue'
 import 'rxjs/add/operator/let';
 import 'rxjs/add/operator/scan';
+import 'rxjs/add/operator/observeOn';
 
 import {Dispatcher} from './dispatcher';
 import {Middleware, Reducer} from './interfaces';
@@ -25,6 +27,7 @@ export class StoreBackend {
   connect(nextCallbackFn: (state: any) => void) {
     this._dispatcher
       .let(this._preMiddleware)
+      .observeOn(queue)
       .scan((state, action) => this._reducer(state, action), this._initialState)
       .let(this._postMiddleware)
       .subscribe(nextCallbackFn);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,5 @@
 		"src/store-backend.ts",
 		"src/dispatcher.ts",
 		"src/ng2.ts"
-	],
-	"exclude": [
-		"node_modules"
 	]
 }


### PR DESCRIPTION
This forces the storeBackend to use a trampoline scheduler, rather than the default recursive scheduler. This should not change behavior for most applications, but does protect against the rare (and ILL-ADVISED) case when values are dispatched back into the store from a store subscriber. 

fixes #79 
