### PR TITLE
Fix to work with rxjs beta.5, solves #85

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "zone.js": "0.5.15"
   },
   "peerDependencies": {
-    "rxjs": "^5.0.0-beta.2",
+    "rxjs": "^5.0.0-beta.5",
     "angular2": "^2.0.0-beta.7"
   },
   "typings": "./dist/index.d.ts"

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,5 @@
 import {Observable} from 'rxjs/Observable';
-import {BehaviorSubject} from 'rxjs/subject/BehaviorSubject';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/distinctUntilChanged';
 


### PR DESCRIPTION
With Rxjs beta.5, BehaviourSubject has been moved directly under the src folder.

Solves #85 
