### PR TITLE
refactor(Store): Remove redundant CacheSubject

### DIFF
--- a/spec/store_spec.ts
+++ b/spec/store_spec.ts
@@ -166,7 +166,7 @@ describe('ngRx Store', () => {
       spyOn(dispatcher, 'next');
       spyOn(dispatcher, 'error');
 
-      store.next(1);
+      store.next(<any>1);
       store.error(2);
 
       expect(dispatcher.next).toHaveBeenCalledWith(1);

--- a/src/ng2.ts
+++ b/src/ng2.ts
@@ -18,9 +18,9 @@ const dispatcherProvider = provide(Dispatcher, {
 });
 
 const storeProvider = provide(Store, {
-  deps: [Dispatcher, Reducer, State, INITIAL_STATE],
-  useFactory(dispatcher: Dispatcher, reducer: Reducer, state$: State<any>, initialState: any) {
-      return new Store<any>(dispatcher, reducer, state$, initialState);
+  deps: [Dispatcher, Reducer, State],
+  useFactory(dispatcher: Dispatcher, reducer: Reducer, state$: State<any>) {
+      return new Store<any>(dispatcher, reducer, state$);
   }
 });
 

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -15,6 +15,10 @@ export class Reducer extends SyncSubject<ActionReducer<any>> {
 
   replaceReducer(reducer: ActionReducer<any>) {
     this.next(reducer);
+  }
+
+  next(reducer: ActionReducer<any>) {
+    super.next(reducer);
     this._dispatcher.dispatch({ type: Reducer.REPLACE });
   }
 }


### PR DESCRIPTION
The State backend observable is already multicasting. It isn't necessary to re-store its value in another CacheSubject. This changes Store to be a vanilla Observable of state and Observer of actions.

No breaking changes.
