### PR TITLE
Fix Circle CI Builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run build_test && jasmine",
     "clean_test": "rm -rf tmp/",
-    "build_test": "npm run clean_test && tsc -p spec",
+    "build_test": "npm run clean_test && npm run typings && tsc -p spec",
     "build_dist": "rm -rf dist && tsc && npm run copy_package",
     "copy_package": "cp package.json dist/package.json",
     "lint": "tslint src/**.ts",


### PR DESCRIPTION
182673f953cbda1a06c88ed8631a358d5272fc3f  removed the `prepublish` step that ran `typings`, which causes Circle CI to fail. This adds a call to `typings` to `build_test` so that it runs before Circle runs `test`.
- Add `npm run typings` to `build_test` step
