### PR TITLE
refactor(Store): Remove SyncSubjects and correctly subclass Observable

### DIFF
--- a/spec/store_spec.ts
+++ b/spec/store_spec.ts
@@ -78,6 +78,14 @@ describe('ngRx Store', () => {
 
     });
 
+    it('should correctly lift itself', function() {
+
+      const result = store.select('t');
+
+      expect(result instanceof Store).toBe(true);
+
+    });
+
     it('should appropriately handle initial state', (done) => {
 
       store.take(1).subscribe({
@@ -166,7 +174,7 @@ describe('ngRx Store', () => {
       spyOn(dispatcher, 'next');
       spyOn(dispatcher, 'error');
 
-      store.next(1);
+      store.next(<any>1);
       store.error(2);
 
       expect(dispatcher.next).toHaveBeenCalledWith(1);

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -1,12 +1,11 @@
-import { SyncSubject } from '@ngrx/core/SyncSubject';
-import {Observable} from 'rxjs/Observable';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 export interface Action {
   type: string;
   payload?: any;
 }
 
-export class Dispatcher extends SyncSubject<Action> {
+export class Dispatcher extends BehaviorSubject<Action> {
   static INIT = '@ngrx/store/init';
 
   constructor() {

--- a/src/ng2.ts
+++ b/src/ng2.ts
@@ -18,9 +18,9 @@ const dispatcherProvider = {
 
 const storeProvider = {
   provide: Store,
-  deps: [Dispatcher, Reducer, State, INITIAL_STATE],
-  useFactory(dispatcher: Dispatcher, reducer: Reducer, state$: State<any>, initialState: any) {
-      return new Store<any>(dispatcher, reducer, state$, initialState);
+  deps: [Dispatcher, Reducer, State],
+  useFactory(dispatcher: Dispatcher, reducer: Reducer, state$: State<any>) {
+      return new Store<any>(dispatcher, reducer, state$);
   }
 };
 

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,4 +1,4 @@
-import { SyncSubject } from '@ngrx/core/SyncSubject';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { Dispatcher, Action } from './dispatcher';
 
@@ -6,7 +6,7 @@ export interface ActionReducer<T> {
   (state: T, action: Action): T;
 }
 
-export class Reducer extends SyncSubject<ActionReducer<any>> {
+export class Reducer extends BehaviorSubject<ActionReducer<any>> {
   static REPLACE = '@ngrx/store/replace-reducer';
 
   constructor(private _dispatcher: Dispatcher, initialReducer: ActionReducer<any>) {
@@ -15,6 +15,10 @@ export class Reducer extends SyncSubject<ActionReducer<any>> {
 
   replaceReducer(reducer: ActionReducer<any>) {
     this.next(reducer);
+  }
+
+  next(reducer: ActionReducer<any>) {
+    super.next(reducer);
     this._dispatcher.dispatch({ type: Reducer.REPLACE });
   }
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -2,12 +2,12 @@ import { withLatestFrom } from 'rxjs/operator/withLatestFrom';
 import { scan } from 'rxjs/operator/scan';
 import { observeOn } from 'rxjs/operator/observeOn';
 import { queue } from 'rxjs/scheduler/queue';
-import { SyncSubject } from '@ngrx/core/SyncSubject';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { Dispatcher } from './dispatcher';
 import { Reducer } from './reducer';
 
-export class State<T> extends SyncSubject<T> {
+export class State<T> extends BehaviorSubject<T> {
   constructor(_initialState: T, action$: Dispatcher, reducer$: Reducer) {
     super(_initialState);
 


### PR DESCRIPTION
Replaces all SyncSubjects with BehaviorSubjects. Use an Observable for Store, subclassing it correctly

cc @blesh @petebacondarwin @brandonroberts 
