### PR TITLE
Use inline source maps, closes #180

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
 		"outDir": "dist",
 		"declaration": true,
     "lib": ["es2015", "dom"],
-    "sourceMap": true
+    "sourceMap": true,
+    "inlineSources": true
 	},
 	"files": [
     "src/index.ts"


### PR DESCRIPTION
There are 2 ways to solve the source maps issue #180:
- Copy the `.ts` files from `src` to `dist` folder  
  Which kinda is against the point of having the `dist` folder separation at all
- Inline the sources in the sourcemaps  
  Which this PR suggests

Checked against the current Angular CLI webpack output.
