### PR TITLE
Add ability to use factory for initial reducer and update to rc.6 and rxjs-beta.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngrx/store",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "RxJS powered Redux for Angular2 apps",
   "main": "./index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   },
   "homepage": "https://github.com/ngrx/store#readme",
   "devDependencies": {
-    "@angular/common": "^2.0.0-rc.5",
-    "@angular/compiler": "^2.0.0-rc.5",
+    "@angular/common": "^2.0.0-rc.6",
+    "@angular/compiler": "^2.0.0-rc.6",
     "@angular/compiler-cli": "^0.5.0",
-    "@angular/core": "^2.0.0-rc.5",
-    "@angular/platform-browser": "^2.0.0-rc.5",
-    "@angular/platform-server": "^2.0.0-rc.5",
+    "@angular/core": "^2.0.0-rc.6",
+    "@angular/platform-browser": "^2.0.0-rc.6",
+    "@angular/platform-server": "^2.0.0-rc.6",
     "@angular/tsc-wrapped": "^0.2.2",
     "@ngrx/core": "^1.0.0",
     "@types/jasmine": "^2.2.31",
@@ -49,7 +49,7 @@
     "lodash": "^3.10.1",
     "reflect-metadata": "0.1.2",
     "rimraf": "^2.5.2",
-    "rxjs": "5.0.0-beta.6",
+    "rxjs": "5.0.0-beta.11",
     "tslint": "^3.4.0",
     "typescript": "next",
     "typings": "^0.8.1",
@@ -57,8 +57,8 @@
   },
   "peerDependencies": {
     "@ngrx/core": "^1.0.0",
-    "rxjs": "^5.0.0-beta.6",
-    "@angular/core": "^2.0.0-rc.5"
+    "rxjs": "^5.0.0-beta.11",
+    "@angular/core": "^2.0.0-rc.6"
   },
   "typings": "./index.d.ts"
 }

--- a/spec/edge_spec.ts
+++ b/spec/edge_spec.ts
@@ -4,7 +4,7 @@ require('reflect-metadata');
 import {Store, Dispatcher, State, Action, combineReducers} from '../src/index';
 import {StoreModule} from '../src/ng2';
 import {Observable} from 'rxjs/Observable';
-import {ReflectiveInjector, provide} from '@angular/core';
+import {ReflectiveInjector } from '@angular/core';
 
 import {todos, todoCount} from './fixtures/edge_todos';
 

--- a/spec/integration_spec.ts
+++ b/spec/integration_spec.ts
@@ -3,7 +3,7 @@ require('es6-shim');
 require('reflect-metadata');
 import {Store, StoreModule, Action, combineReducers, INITIAL_REDUCER, INITIAL_STATE} from '../src/index';
 import {Observable} from 'rxjs/Observable';
-import {ReflectiveInjector, provide} from '@angular/core';
+import {ReflectiveInjector } from '@angular/core';
 import 'rxjs/add/observable/combineLatest';
 
 import {counterReducer, INCREMENT, DECREMENT, RESET} from './fixtures/counter';

--- a/spec/ng2_spec.ts
+++ b/spec/ng2_spec.ts
@@ -25,23 +25,25 @@ interface TodoAppSchema {
 
 describe('ngRx Store', () => {
 
-  describe('basic store actions', function() {
+  describe('basic store wtih useFactory', function() {
 
     let injector: ReflectiveInjector;
     let store: Store<TestAppSchema>;
     let dispatcher: Dispatcher;
 
     beforeEach(() => {
-      const rootReducer = combineReducers({
-        counter1: counterReducer,
-        counter2: counterReducer,
-        counter3: counterReducer
-      });
+      function rootReducer(){
+        return combineReducers({
+          counter1: counterReducer,
+          counter2: counterReducer,
+          counter3: counterReducer
+        });
+      }
 
       const initialValue = { counter1: 0, counter2: 1 };
 
       injector = ReflectiveInjector.resolveAndCreate([
-        StoreModule.provideStore(rootReducer, initialValue).providers
+        StoreModule.provideStore(rootReducer, initialValue, true).providers
       ]);
 
       store = injector.get(Store);

--- a/spec/state_spec.ts
+++ b/spec/state_spec.ts
@@ -3,7 +3,7 @@ require('es6-shim');
 require('reflect-metadata');
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
-import {ReflectiveInjector, provide} from '@angular/core';
+import {ReflectiveInjector } from '@angular/core';
 
 import {Dispatcher, State, Reducer, Action, provideStore, StoreModule} from '../src/index';
 

--- a/spec/tsconfig.json
+++ b/spec/tsconfig.json
@@ -16,6 +16,7 @@
     "integration_spec.ts",
 		"store_spec.ts",
 		"state_spec.ts",
-    "edge_spec.ts"
+    "edge_spec.ts",
+		"ng2_spec.ts"
 	]
 }

--- a/src/ng2.ts
+++ b/src/ng2.ts
@@ -40,7 +40,11 @@ export function _reducerFactory(dispatcher, reducer) {
 /**
  * @deprecated, use StoreModule.provideStore instead!
  */
-export function provideStore(_reducer: any, _initialState?: any): any[] {
+export function provideStore(_reducer: any, _initialState?: any, useFactory = false): any[] {
+  let InitialReducerProvider: any = { provide: _INITIAL_REDUCER, useValue: _reducer };
+  if(useFactory){
+    InitialReducerProvider = { provide: _INITIAL_REDUCER, useFactory: _reducer };
+  }
   return [
     Dispatcher,
     { provide: Store, useFactory: _storeFactory, deps: [Dispatcher, Reducer, State] },
@@ -49,17 +53,17 @@ export function provideStore(_reducer: any, _initialState?: any): any[] {
     { provide: INITIAL_REDUCER, useFactory: _initialReducerFactory, deps: [_INITIAL_REDUCER] },
     { provide: INITIAL_STATE, useFactory: _initialStateFactory, deps: [_INITIAL_STATE, INITIAL_REDUCER] },
     { provide: _INITIAL_STATE, useValue: _initialState },
-    { provide: _INITIAL_REDUCER, useFactory: _reducer }
+    InitialReducerProvider
   ];
 }
 
 
 @NgModule({})
 export class StoreModule {
-  static provideStore(_reducer: any, _initialState?:any): ModuleWithProviders {
+  static provideStore(_reducer: any, _initialState?:any, useFactory = false): ModuleWithProviders {
     return {
       ngModule: StoreModule,
-      providers: provideStore(_reducer, _initialState)
+      providers: provideStore(_reducer, _initialState, useFactory)
     };
   }
 }

--- a/src/ng2.ts
+++ b/src/ng2.ts
@@ -49,7 +49,7 @@ export function provideStore(_reducer: any, _initialState?: any): any[] {
     { provide: INITIAL_REDUCER, useFactory: _initialReducerFactory, deps: [_INITIAL_REDUCER] },
     { provide: INITIAL_STATE, useFactory: _initialStateFactory, deps: [_INITIAL_STATE, INITIAL_REDUCER] },
     { provide: _INITIAL_STATE, useValue: _initialState },
-    { provide: _INITIAL_REDUCER, useValue: _reducer }
+    { provide: _INITIAL_REDUCER, useFactory: _reducer }
   ];
 }
 


### PR DESCRIPTION
Rxjs Update:
https://github.com/ngrx/store/issues/204

Fix for Aot compilation:
https://github.com/ngrx/store/issues/190

I am open to suggestions but wanted to start by adding a parameter to useFactory so provideStore would be backwards compatible. 
