### PR TITLE
Added support for nesting in the combineReducers utility method.

### DIFF
--- a/spec/edge_spec.ts
+++ b/spec/edge_spec.ts
@@ -4,7 +4,7 @@ require('reflect-metadata');
 import {Store, Dispatcher, State, Action, combineReducers} from '../src/index';
 import {StoreModule} from '../src/ng2';
 import {Observable} from 'rxjs/Observable';
-import {ReflectiveInjector, provide} from '@angular/core';
+import {ReflectiveInjector} from '@angular/core';
 
 import {todos, todoCount} from './fixtures/edge_todos';
 

--- a/spec/integration_spec.ts
+++ b/spec/integration_spec.ts
@@ -3,7 +3,7 @@ require('es6-shim');
 require('reflect-metadata');
 import {Store, StoreModule, Action, combineReducers, INITIAL_REDUCER, INITIAL_STATE} from '../src/index';
 import {Observable} from 'rxjs/Observable';
-import {ReflectiveInjector, provide} from '@angular/core';
+import {ReflectiveInjector} from '@angular/core';
 import 'rxjs/add/observable/combineLatest';
 
 import {counterReducer, INCREMENT, DECREMENT, RESET} from './fixtures/counter';

--- a/spec/state_spec.ts
+++ b/spec/state_spec.ts
@@ -3,7 +3,7 @@ require('es6-shim');
 require('reflect-metadata');
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
-import {ReflectiveInjector, provide} from '@angular/core';
+import {ReflectiveInjector} from '@angular/core';
 
 import {Dispatcher, State, Reducer, Action, provideStore, StoreModule} from '../src/index';
 

--- a/spec/store_spec.ts
+++ b/spec/store_spec.ts
@@ -1,12 +1,10 @@
 declare var describe, it, expect, hot, cold, expectObservable, expectSubscriptions, console, beforeEach;
 require('es6-shim');
 require('reflect-metadata');
-import 'rxjs/add/operator/take';
-import {Store, Dispatcher, State, Action, combineReducers, StoreModule} from '../src/index';
-import {Observable} from 'rxjs/Observable';
-import {ReflectiveInjector, provide} from '@angular/core';
-
-import {counterReducer, INCREMENT, DECREMENT, RESET} from './fixtures/counter';
+import "rxjs/add/operator/take";
+import {Store, Dispatcher, combineReducers, StoreModule} from "../src/index";
+import {ReflectiveInjector} from "@angular/core";
+import {counterReducer, INCREMENT, DECREMENT, RESET} from "./fixtures/counter";
 
 interface TestAppSchema {
   counter1: number;
@@ -14,13 +12,22 @@ interface TestAppSchema {
   counter3: number;
 }
 
-interface Todo { }
+interface TestAppSchema2 {
+  counter1: number;
+  counter2: TestAppSchemaCounter2;
+}
+
+interface TestAppSchemaCounter2 {
+  counter2a: number;
+}
+
+interface Todo {
+}
 
 interface TodoAppSchema {
   visibilityFilter: string;
   todos: Todo[];
 }
-
 
 
 describe('ngRx Store', () => {
@@ -192,6 +199,90 @@ describe('ngRx Store', () => {
 
       expect(storeSubscription.isUnsubscribed).toBe(false);
       expect(dispatcherSubscription.isUnsubscribed).toBe(false);
+    });
+  });
+
+  describe('store with nested reducer tree', () => {
+    let injector: ReflectiveInjector;
+    let store: Store<TestAppSchema2>;
+    let dispatcher: Dispatcher;
+
+    beforeEach(() => {
+      const rootReducer = combineReducers({
+        counter1: counterReducer,
+        counter2: {
+          counter2a: counterReducer
+        }
+      });
+
+      const initialValue =
+      {
+        counter1: 0,
+        counter2: {
+          counter2a: 1
+        }
+      };
+
+      injector = ReflectiveInjector.resolveAndCreate([
+        StoreModule.provideStore(rootReducer, initialValue).providers
+      ]);
+
+      store = injector.get(Store);
+      dispatcher = injector.get(Dispatcher);
+    });
+
+    const actionSequence = '--a--b--c--d--e';
+    const actionValues = {
+      a: {type: INCREMENT},
+      b: {type: INCREMENT},
+      c: {type: DECREMENT},
+      d: {type: RESET},
+      e: {type: INCREMENT}
+    };
+
+    it('should create a nested reducer structure', () => {
+      const storeStructure = store.select(s => s);
+
+      store.take(1).subscribe((state) => {
+        expect(state).toEqual({counter1: 0, counter2: {counter2a: 1}});
+      });
+    });
+
+    it('should let you select the nested state via string or function', function () {
+
+      const counterSteps = hot(actionSequence, actionValues);
+
+      counterSteps.subscribe((action) => store.dispatch(action));
+
+      const counterStateWithString = store.select('counter2','counter2a');
+      const counterStateWithFunc = store.select(s => s.counter2.counter2a);
+
+      const stateSequence = 'i-v--w--x--y--z';
+      const counter2aValues = {i: 1, v: 2, w: 3, x: 2, y: 0, z: 1};
+
+      expectObservable(counterStateWithString).toBe(stateSequence, counter2aValues);
+      expectObservable(counterStateWithFunc).toBe(stateSequence, counter2aValues);
+    });
+
+    it('should increment and decrement counter2', function () {
+
+      const counterSteps = hot(actionSequence, actionValues);
+
+      counterSteps.subscribe((action) => store.dispatch(action));
+
+      const counterState = store.select('counter2');
+
+      const stateSequence = 'i-v--w--x--y--z';
+      const counter1Values = {
+        i: {counter2a: 1},
+        v: {counter2a: 2},
+        w: {counter2a: 3},
+        x: {counter2a: 2},
+        y: {counter2a: 0},
+        z: {counter2a: 1}
+      };
+
+      expectObservable(counterState).toBe(stateSequence, counter1Values);
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,8 @@ export function combineReducers(reducers: any): ActionReducer<any> {
     const key = reducerKeys[i];
     if (typeof reducers[key] === 'function') {
       finalReducers[key] = reducers[key];
+    } else {
+      finalReducers[key] = combineReducers(reducers[key]);
     }
   }
 


### PR DESCRIPTION
## Current situation

During design of your state tree, you typically divide it up into different sections. F.e.

``` javascript
{
  ui: uiReducer,
  data: dataReducer
}
```

NGRX/Store provides the combineReducers method to easily work with such structures.
## Problem description

If you want to work with multiple levels of nesting in your state tree, you need to do something else F.e.

``` javascript
{
  ui: {
      login:...,
      main: ... 
  } ,
  data: ...
}
```

In that case, you'd could:
1. Write a uiReducer yourself which delegates every action related to login to a loginReducer and every 'main' related action to the mainReducer.
2. Use a utility such as: https://github.com/brechtbilliet/create-reducer-tree which handles this for you
3. Nest the combineReducers method like this:

``` javascript
const rootReducer = 
{
   ui: combineReducers({
         login: loginReducer,
         main: mainReducer
  }),
  data: dataReducer
}
```
## Improvement description

Option 1 provides you with extra work and option 2 forces you to work with a third party library. I personally prefer option 3 where you nest the combineReducers method inside your tree. 
This could actually be easily integrated into the current combineReducers method and make the following possible:

``` javascript
rootReducer = {
   ui: {
      login: loginReducer,
      main: mainReducer
   },
   data: dataReducer
}

new Store(rootReducer)
```

It's a lot cleaner than approach where you nest the combineReducers method yourself.
This implemented by making the combineReducers function a recursive one. 

Happy to hear any feedback on the feature request/implementation :).

I also created test for this functionality. If you feel these are insufficient or not in the correct place/file, I'm happy to change this as per your instructions.
