### PR TITLE
Use top level Core export of select.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ export default {
   moduleName: 'ngrx.store',
   globals: {
     '@angular/core': 'ng.core',
-    '@ngrx/core/operator/select': 'ngrx.core',
+    '@ngrx/core': 'ngrx.core',
     'rxjs/Observable': 'Rx',
     'rxjs/BehaviorSubject': 'Rx',
     'rxjs/Subscriber': 'Rx',

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,4 @@
-import { select, SelectSignature } from '@ngrx/core/operator/select';
+import { select, SelectSignature } from '@ngrx/core';
 import { Observer } from 'rxjs/Observer';
 import { Observable } from 'rxjs/Observable';
 import { Subscriber } from 'rxjs/Subscriber';


### PR DESCRIPTION
This makes store and core jointly more compatible with the use case where you want to load them both via UMDs using SystemJS. By using the new top level export from core, store no longer needs to configure (in the rollup config) a way to reach deeper inside.
