### PR TITLE
Updated readme to remove type error

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ class MyApp {
 	counter: Observable<number>;
 
 	constructor(public store: Store<AppState>){
-		this.counter = store.select('counter');
+		this.counter = store.select(s => s.counter);
 	}
 
 	increment(){


### PR DESCRIPTION
Following the readme would lead to the error `Type 'Observable<{}>' is not assignable to type 'Observable<number>'` as discussed here https://github.com/ngrx/store/issues/183
