### PR TITLE
fixed store.select to resolve TS2322 type error

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ class MyAppComponent {
 	counter: Observable<number>;
 
 	constructor(private store: Store<AppState>){
-		this.counter = store.select('counter');
+		this.counter = store.select<number>('counter');
 	}
 
 	increment(){


### PR DESCRIPTION
The sample code in the readme doesn't work without added a type to the store.select line in the app constructor. 
