### PR TITLE
Update dispatcher.ts

### DIFF
--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -1,7 +1,7 @@
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 export interface Action {
-  type: string;
+  type?: string;
   payload?: any;
 }
 


### PR DESCRIPTION
If "type" is not optional @Effect() throws a typescript error on `Observable<Action>`. This is due to the fact that "type" on the Action interface was required.