### PR TITLE
Provide option to send extra data

### DIFF
--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -3,6 +3,7 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 export interface Action {
   type: string;
   payload?: any;
+  meta?: any;
 }
 
 export class Dispatcher extends BehaviorSubject<Action> {


### PR DESCRIPTION
Proposed feature:

Provide option to send extra data through optional meta field.

Why: 

In many situation I need to pass extra data to be consumed by different Effects.

One example would be for an Alert reducer, enabling us to pass "success/fail" messages from any action.

Example flux:
1. dispatch LOGIN action with payload and ```meta = {successMessage: "Welcome!"}```.
2. LOGIN effect passes meta to LOGIN_SUCCESS action after its own logic.
3. ALERT reducer listening to LOGIN_SUCCESS changes its state: ```return action.meta.successMessage;```