### PR TITLE
Expanding wildcard exports so that ngrx/store can be used with Google…

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,10 @@
-import * as __private_export__ from './src/private_export';
-
+export { ActionsSubject } from './src/private_export';
+export { ReducerManager, ReducerObservable } from './src/private_export';
+export { ScannedActionsSubject } from './src/private_export';
+export { State, StateObservable, reduceState } from './src/private_export';
+export { INITIAL_STATE, REDUCER_FACTORY, INITIAL_REDUCERS, STORE_FEATURES } from './src/private_export';
+export { StoreRootModule, StoreFeatureModule } from './src/private_export';
 export { Action, ActionReducer, ActionReducerMap, ActionReducerFactory } from './src/models';
 export { StoreModule } from './src/store_module';
 export { Store } from './src/store';
 export { combineReducers, compose } from './src/utils';
-export { __private_export__ };
-


### PR DESCRIPTION
… Closure Compiler in Advanced mode.

Expanding wildcard exports in the main TS file to allow the @ngrx/store library to be processed by the Closure Compiler in ADVANCED_OPTIMIZATIONS mode. GCC doesn't support wildcard exports.

So this change expands those wildcards and makes this library closure-friendly given that ES6 > Closure will be the preferred production build pipeline for Angular 4x apps, which currently offers the best compression ratios possible.