### PR TITLE
feat(models): make action a generic type

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -1,5 +1,6 @@
-export interface Action {
+export interface Action<T = any> {
   readonly type: string;
+  readonly payload?: T;
 }
 
 export interface ActionReducer<T, V extends Action> {


### PR DESCRIPTION
This is not an actual PR, more like proposal for consideration
Typesafe maniac like would be really grateful for strictly typed Action

TS v2.2+ introduces defaults for generic types
so `Action<T = any>` means Action is generic, but it will be any if type not provided

What do you think?

TS proposal here:
https://github.com/Microsoft/TypeScript/issues/2175