### PR TITLE
Turn on noImplicitAny

### DIFF
--- a/spec/fixtures/counter.ts
+++ b/spec/fixtures/counter.ts
@@ -2,7 +2,7 @@ export const INCREMENT = 'INCREMENT';
 export const DECREMENT = 'DECREMENT';
 export const RESET = 'RESET';
 
-export function counterReducer(state = 0, action){
+export function counterReducer(state = 0, action: any) {
   switch (action.type) {
     case INCREMENT:
       return state + 1;

--- a/spec/fixtures/edge_todos.ts
+++ b/spec/fixtures/edge_todos.ts
@@ -1,4 +1,4 @@
-const todo = (state, action) => {
+const todo = (state: any, action: any) => {
   switch (action.type) {
     case 'ADD_TODO':
       return {
@@ -20,7 +20,7 @@ const todo = (state, action) => {
   }
 }
 
-export const todos = (state = [], action) => {
+export const todos = (state: any[] = [], action: any) => {
   switch (action.type) {
     case 'ADD_TODO':
       return [
@@ -36,7 +36,7 @@ export const todos = (state = [], action) => {
   }
 }
 
-export const todoCount = (state = 0, action) => {
+export const todoCount = (state = 0, action: any) => {
   switch(action.type){
     case 'SET_COUNT':
       return action.payload;

--- a/spec/fixtures/todos.ts
+++ b/spec/fixtures/todos.ts
@@ -11,7 +11,7 @@ export const VisibilityFilters = {
   SHOW_ACTIVE: 'SHOW_ACTIVE'
 };
 
-export function visibilityFilter(state = VisibilityFilters.SHOW_ALL, {type, payload}) {
+export function visibilityFilter(state = VisibilityFilters.SHOW_ALL, {type, payload}: {type: string, payload: any}) {
   switch (type) {
     case SET_VISIBILITY_FILTER:
       return payload;
@@ -20,7 +20,7 @@ export function visibilityFilter(state = VisibilityFilters.SHOW_ALL, {type, payl
   }
 };
 
-export function todos(state = [], {type, payload}) {
+export function todos(state: any[] = [], {type, payload}: {type: string, payload: any}) {
   switch (type) {
     case ADD_TODO:
       return [

--- a/spec/helpers/marble-testing.ts
+++ b/spec/helpers/marble-testing.ts
@@ -1,4 +1,4 @@
-declare var global;
+declare var global: any;
 
 function hot(...args: any[]) {
   if (!global.rxTestScheduler) {
@@ -28,7 +28,7 @@ function expectSubscriptions(...args: any[]) {
   return global.rxTestScheduler.expectSubscriptions.apply(global.rxTestScheduler, arguments);
 }
 
-function assertDeepEqual(actual, expected) {
+function assertDeepEqual(actual: any, expected: any) {
   (<any> expect(actual)).toDeepEqual(expected);
 }
 

--- a/spec/helpers/test-helper.ts
+++ b/spec/helpers/test-helper.ts
@@ -1,4 +1,4 @@
-declare var global, require, Symbol;
+declare var global: any, require: Function, Symbol: any;
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
 
@@ -18,7 +18,7 @@ const assertDeepEqual = marbleHelpers.assertDeepEqual;
 
 const glit = global.it;
 
-global.it = function(description, cb, timeout) {
+global.it = function(description: any, cb: any, timeout: any) {
   if (cb.length === 0) {
     glit(description, function() {
       global.rxTestScheduler = new TestScheduler(assertDeepEqual);
@@ -36,7 +36,7 @@ global.it.asDiagram = function() {
 
 const glfit = global.fit;
 
-global.fit = function(description, cb, timeout) {
+global.fit = function(description: any, cb: any, timeout: any) {
   if (cb.length === 0) {
     glfit(description, function() {
       global.rxTestScheduler = new TestScheduler(assertDeepEqual);
@@ -48,7 +48,7 @@ global.fit = function(description, cb, timeout) {
   }
 };
 
-function stringify(x) {
+function stringify(x: any): string {
   return JSON.stringify(x, function(key, value) {
     if (Array.isArray(value)) {
       return '[' + value
@@ -67,7 +67,7 @@ beforeEach(function() {
   jasmine.addMatchers({
     toDeepEqual: function(util, customEqualityTesters) {
       return {
-        compare: function(actual, expected) {
+        compare: function(actual: any, expected: any) {
           let result: any = { pass: _.isEqual(actual, expected) };
 
           if (!result.pass && Array.isArray(actual) && Array.isArray(expected)) {
@@ -95,7 +95,7 @@ afterEach(function() {
 (function() {
   Object.defineProperty(Error.prototype, 'toJSON', {
     value: function() {
-      let alt = {};
+      let alt: { [key: string]: any } = {};
 
       Object.getOwnPropertyNames(this).forEach(function(key) {
         if (key !== 'stack') {
@@ -113,9 +113,9 @@ afterEach(function() {
 global.lowerCaseO = function lowerCaseO() {
   const values = [].slice.apply(arguments);
 
-  const o = {
-    subscribe: function(observer) {
-      values.forEach(function(v) {
+  const o: { [key: string]: any } = {
+    subscribe: function(observer: any) {
+      values.forEach(function(v: any) {
         observer.next(v);
       });
       observer.complete();

--- a/spec/integration.spec.ts
+++ b/spec/integration.spec.ts
@@ -26,7 +26,7 @@ describe('ngRx Integration spec', () => {
     let currentState: TodoAppSchema;
 
     const rootReducer = combineReducers({ todos, visibilityFilter });
-    const initialValue = { todos: [], visibilityFilter: VisibilityFilters.SHOW_ALL };
+    const initialValue = { todos: (<any[]> []), visibilityFilter: VisibilityFilters.SHOW_ALL };
 
     injector = ReflectiveInjector.resolveAndCreate([
       StoreModule.provideStore(rootReducer, initialValue).providers
@@ -104,21 +104,21 @@ describe('ngRx Integration spec', () => {
 
     it('should use visibilityFilter to filter todos', () => {
 
-      const filterVisibleTodos = (visibilityFilter, todos) => {
+      const filterVisibleTodos = (visibilityFilter: any, todos: any) => {
         let predicate;
         if (visibilityFilter === VisibilityFilters.SHOW_ALL) {
           predicate = () => true;
         }
         else if (visibilityFilter === VisibilityFilters.SHOW_ACTIVE) {
-          predicate = (todo) => !todo.completed;
+          predicate = (todo: any) => !todo.completed;
         }
         else {
-          predicate = (todo) => todo.completed;
+          predicate = (todo: any) => todo.completed;
         }
         return todos.filter(predicate);
       };
 
-      let currentlyVisibleTodos;
+      let currentlyVisibleTodos: any[] = [];
 
       Observable.combineLatest(store.select('visibilityFilter'), store.select('todos'), filterVisibleTodos)
         .subscribe(visibleTodos => {

--- a/spec/ngc/tsconfig.ngc.json
+++ b/spec/ngc/tsconfig.ngc.json
@@ -1,16 +1,17 @@
 {
-	"compilerOptions": {
-		"target": "ES5",
-		"emitDecoratorMetadata": true,
-		"experimentalDecorators": true,
-		"module": "commonjs",
-		"moduleResolution": "node",
-		"outDir": "./output",
+  "compilerOptions": {
+    "target": "ES5",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "outDir": "./output",
     "lib": ["es2015", "dom"]
-	},
-	"files": [
+  },
+  "files": [
     "main.ts"
-	],
+  ],
   "angularCompilerOptions": {
     "genDir": "ngfactory"
   }

--- a/spec/state.spec.ts
+++ b/spec/state.spec.ts
@@ -6,7 +6,7 @@ import {Dispatcher, State, Reducer, Action, provideStore, StoreModule} from '../
 
 
 describe('ngRx State', () => {
-  const Reducer = { reduce: t => t };
+  const Reducer = { reduce: (t: any) => t };
   const initialState = 123;
   let injector: ReflectiveInjector;
   let state: State<number>;

--- a/spec/store.spec.ts
+++ b/spec/store.spec.ts
@@ -63,7 +63,7 @@ describe('ngRx Store', () => {
 
       const counterSteps = hot(actionSequence, actionValues);
 
-      counterSteps.subscribe((action) => store.dispatch(action));
+      counterSteps.subscribe((action: any) => store.dispatch(action));
 
       const counterStateWithString = store.select('counter1');
       const counterStateWithFunc = store.select(s => s.counter1);
@@ -100,7 +100,7 @@ describe('ngRx Store', () => {
 
       const counterSteps = hot(actionSequence, actionValues);
 
-      counterSteps.subscribe((action) => store.dispatch(action));
+      counterSteps.subscribe((action: any) => store.dispatch(action));
 
       const counterState = store.select('counter1');
 
@@ -115,7 +115,7 @@ describe('ngRx Store', () => {
 
       const counterSteps = hot(actionSequence, actionValues);
 
-      counterSteps.subscribe((action) => dispatcher.dispatch(action));
+      counterSteps.subscribe((action: any) => dispatcher.dispatch(action));
 
       const counterState = store.select('counter1');
 
@@ -131,7 +131,7 @@ describe('ngRx Store', () => {
 
       const counterSteps = hot(actionSequence, actionValues);
 
-      counterSteps.subscribe((action) => store.dispatch(action));
+      counterSteps.subscribe((action: any) => store.dispatch(action));
 
       const counter1State = store.select('counter1');
       const counter2State = store.select('counter2');

--- a/src/ng2.ts
+++ b/src/ng2.ts
@@ -1,7 +1,9 @@
 import { OpaqueToken, NgModule, ModuleWithProviders } from '@angular/core';
+import { Observer } from 'rxjs/Observer';
+import { Observable } from 'rxjs/Observable';
 
-import { Reducer } from './reducer';
-import { Dispatcher } from './dispatcher';
+import { ActionReducer, Reducer } from './reducer';
+import { Action, Dispatcher } from './dispatcher';
 import { Store } from './store';
 import { State } from './state';
 import { combineReducers } from './utils';
@@ -12,21 +14,21 @@ export const INITIAL_STATE = new OpaqueToken('Token ngrx/store/initial-state');
 export const _INITIAL_REDUCER = new OpaqueToken('Token _ngrx/store/reducer');
 export const _INITIAL_STATE = new OpaqueToken('Token _ngrx/store/initial-state');
 
-export function _initialReducerFactory(reducer) {
+export function _initialReducerFactory(reducer: any) {
   if (typeof reducer === 'function') {
     return reducer;
   }
   return combineReducers(reducer);
 }
 
-export function _initialStateFactory(initialState, reducer) {
+export function _initialStateFactory(initialState: any, reducer: Function) {
   if (!initialState) {
     return reducer(undefined, { type: Dispatcher.INIT });
   }
   return initialState;
 }
 
-export function _storeFactory(dispatcher, reducer, state$) {
+export function _storeFactory(dispatcher: Observer<Action>, reducer: Observer<ActionReducer<any>>, state$: Observable<any>) {
   return new Store(dispatcher, reducer, state$);
 }
 
@@ -34,7 +36,7 @@ export function _stateFactory(initialState: any, dispatcher: Dispatcher, reducer
   return new State(initialState, dispatcher, reducer);
 }
 
-export function _reducerFactory(dispatcher, reducer) {
+export function _reducerFactory(dispatcher: Dispatcher, reducer: ActionReducer<any>) {
   return new Reducer(dispatcher, reducer);
 };
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -13,10 +13,10 @@ export class State<T> extends BehaviorSubject<T> {
 
     const actionInQueue$ = observeOn.call(action$, queue);
     const actionAndReducer$ = withLatestFrom.call(actionInQueue$, reducer$);
-    const state$ = scan.call(actionAndReducer$, (state, [ action, reducer ]) => {
+    const state$ = scan.call(actionAndReducer$, (state: any, [ action, reducer ]: [any, any]) => {
       return reducer(state, action);
     }, _initialState);
 
-    state$.subscribe(value => this.next(value));
+    state$.subscribe((value: any) => this.next(value));
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import {ActionReducer} from './reducer';
 
 export function combineReducers(reducers: any): ActionReducer<any> {
   const reducerKeys = Object.keys(reducers);
-  const finalReducers = {};
+  const finalReducers: { [key: string]: Function } = {};
 
   for (let i = 0; i < reducerKeys.length; i++) {
     const key = reducerKeys[i];
@@ -15,7 +15,7 @@ export function combineReducers(reducers: any): ActionReducer<any> {
 
   return function combination(state = {}, action) {
     let hasChanged = false;
-    const nextState = {};
+    const nextState: { [key: string]: any } = {};
     for (let i = 0; i < finalReducerKeys.length; i++) {
       const key = finalReducerKeys[i];
       const reducer = finalReducers[key];

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -8,6 +8,7 @@
     "experimentalDecorators": true,
     "module": "es2015",
     "moduleResolution": "node",
+    "noImplicitAny": true,
     "noEmitOnError": false,
     "outDir": "./release",
     "rootDir": ".",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "experimentalDecorators": true,
     "module": "commonjs",
     "moduleResolution": "node",
+    "noImplicitAny": true,
     "noEmitOnError": false,
     "outDir": "./release",
     "rootDir": ".",
@@ -19,7 +20,7 @@
     ]
   },
   "exclude": [
-	  "node_modules"
+    "node_modules"
   ],
   "angularCompilerOptions": {
     "strictMetadataEmit": true


### PR DESCRIPTION
We are using this library in a project where we would like to use all type checking features of TypeScript.
Unfortunately, ngrx does not compy with `noImplicitAny`. At least so far.

This change adds type annotations where necessary while trying to change as little as possible.
In many cases, I would think there are better options than `any`, but I didn't want to change imports in most cases.